### PR TITLE
gitHubのトークン入力SecureFieldを作りました。gitHubAccessTokenはあとで暗号化処理するコードに投げる予定なのでとりあえず変数に入れてます。 AIに聞いたらgitHub Access Tokenなどの技術用語は英語で記載した方がいいということだったので英語にしてあります。

### DIFF
--- a/yt-mac-menu/yt-mac-menu/GitHubTokenSection.swift
+++ b/yt-mac-menu/yt-mac-menu/GitHubTokenSection.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct GitHubTokenSectionView: View {
+    
+    // 後で暗号化処理に渡す想定
+    @State private var gitHubAccessToken: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            
+            Text("GitHub Access Token")
+                .font(.headline)
+
+            SecureField("トークンを入力", text: $gitHubAccessToken)
+                .textFieldStyle(.roundedBorder)
+                .frame(minWidth: 300)
+
+            Text("入力されたトークンは保存されず、GitHub認証にのみ使用されます。")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    GitHubTokenSectionView()
+}


### PR DESCRIPTION
## Issue
- Close #4

## 概要
- SecureField を使用した入力欄作成
- Token のマスク表示
- 入力値を一時保持