### PR TITLE
SettingViewでトークン入力のViewとプロジェクトパス入力のViewをまとめて表示してます。Viewを表示するためにApp.Swiftも少し編集したのでそちらにも差分が発生しています。

### DIFF
--- a/yt-mac-menu/yt-mac-menu/SettingView.swift
+++ b/yt-mac-menu/yt-mac-menu/SettingView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        VStack {
+            ProjectPathSectionView()
+            GitHubTokenSectionView() //まだissue-#4のプルリクが通ってないのでファイルが見つからずエラーが出ますが許してください
+        }
+        .frame(width: 480)
+        .padding()
+    }
+}

--- a/yt-mac-menu/yt-mac-menu/yt_mac_menuApp.swift
+++ b/yt-mac-menu/yt-mac-menu/yt_mac_menuApp.swift
@@ -13,10 +13,14 @@ struct yt_mac_menuApp: App {
         MenuBarExtra("yt-mac-menu", systemImage: "star.fill") {
             Button("Settings") {
             }
+            SettingsLink() //下のSettingsを呼ぶ
             Divider()
             Button("Quit") {
                 NSApplication.shared.terminate(nil)
             }
+        }
+        Settings {
+            SettingsView()
         }
     }
 }


### PR DESCRIPTION
## Issue
- Close #6 

## 概要
- Settings 画面用 Window / Sheet 作成
- メニュー「Settings」から画面を開く
- 既に開いている場合の多重起動防止