### PR TITLE
Issue-24,25,26：リファクタリング

### DIFF
--- a/yt-mac-menu/yt-mac-menu/Controllers/CameraWindowController.swift
+++ b/yt-mac-menu/yt-mac-menu/Controllers/CameraWindowController.swift
@@ -6,6 +6,7 @@ class CameraWindowController: NSObject, NSWindowDelegate {
     private let service = GestureService.shared
     
     private var window: NSWindow?
+    private var isProgrammaticClose = false
     
     private override init() {
         super.init()
@@ -50,11 +51,17 @@ class CameraWindowController: NSObject, NSWindowDelegate {
         self.window = newWindow
     }
     func close() {
+        isProgrammaticClose = true
         window?.close()
     }
     
     func windowWillClose(_ notification: Notification) {
-        service.disconnect()
+        if isProgrammaticClose {
+            isProgrammaticClose = false
+            
+        } else {
+            service.disconnect()
+        }
         window = nil
     }
 }

--- a/yt-mac-menu/yt-mac-menu/ViewModels/AppViewModel.swift
+++ b/yt-mac-menu/yt-mac-menu/ViewModels/AppViewModel.swift
@@ -28,11 +28,18 @@ class AppViewModel: ObservableObject {
                     self.service.sendCommand("enable_heart")
                     self.isCameraVisible = true
                 case .heartDetected:
-                    self.isCameraVisible = false
+                    self.service.sendCommand("disable_heart")
+                    scheduleAutoReset()
+                    self.service.sendCommand("enable_snap")
                 default:
                     break
                 }
             }
             .store(in: &cancellables)
+    }
+    private func scheduleAutoReset() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+            self?.isCameraVisible = false
+        }
     }
 }

--- a/yt-mac-menu/yt-mac-menu/ViewModels/AppViewModel.swift
+++ b/yt-mac-menu/yt-mac-menu/ViewModels/AppViewModel.swift
@@ -29,17 +29,19 @@ class AppViewModel: ObservableObject {
                     self.isCameraVisible = true
                 case .heartDetected:
                     self.service.sendCommand("disable_heart")
-                    scheduleAutoReset()
-                    self.service.sendCommand("enable_snap")
+                    scheduleAutoReset {
+                        self.service.sendCommand("enable_snap")
+                    }
                 default:
                     break
                 }
             }
             .store(in: &cancellables)
     }
-    private func scheduleAutoReset() {
+    private func scheduleAutoReset(onComplete: (() -> Void)? = nil) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
             self?.isCameraVisible = false
+            onComplete?()
         }
     }
 }

--- a/yt-mac-menu/yt-mac-menu/ViewModels/GestureCameraViewModel.swift
+++ b/yt-mac-menu/yt-mac-menu/ViewModels/GestureCameraViewModel.swift
@@ -6,8 +6,8 @@ class GestureCameraViewModel: ObservableObject {
     @Published var appState: AppStatus = .waiting {
         didSet { handleStateChange(appState) }
     }
-    @Published var handCount: Int = 0
     @Published var session = AVCaptureSession()
+
     
     private let service = GestureService.shared
     private var cancellables = Set<AnyCancellable>()
@@ -32,27 +32,13 @@ class GestureCameraViewModel: ObservableObject {
             .sink { [weak self] event in
                 guard let self = self else { return }
                 switch event {
-                case .connected:
-                    self.service.sendCommand("enable_heart")
                 case .heartDetected:
-                    self.service.sendCommand("disable_heart")
-                    self.service.sendCommand("enable_snap")
                     self.appState = .success
-                    
-                case .handCount(let count):
-                    self.handCount = count
-                    
                 default:
                     break
                 }
             }
             .store(in: &cancellables)
-    }
-    
-    private func scheduleAutoReset() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
-            self?.appState = .waiting
-        }
     }
     
     private func handleStateChange(_ state: AppStatus) {
@@ -61,9 +47,8 @@ class GestureCameraViewModel: ObservableObject {
             self.startSession()
         case .success:
             self.stopSession()
-            self.scheduleAutoReset()
         case .waiting:
-            self.handCount = 0
+            break
         case .unauthorized:
             break
         }

--- a/yt-mac-menu/yt-mac-menu/ViewModels/GestureDetectionViewModel.swift
+++ b/yt-mac-menu/yt-mac-menu/ViewModels/GestureDetectionViewModel.swift
@@ -3,79 +3,36 @@ import Combine
 import SwiftUI
 
 class GestureDetectionViewModel: ObservableObject {
-    @Published var appState: AppStatus = .waiting {
-        didSet { handleStateChange(appState) }
-    }
-    private var monitorWindow: NSWindow?
-    private var webSocketTask: URLSessionWebSocketTask?
-
+    @Published var appState: AppStatus = .waiting
+    private var cancellables = Set<AnyCancellable>()
+    
+    private let service = GestureService.shared
+    
     enum AppStatus: String {
         case waiting
         case detecting
         case success
+        case unauthorized
     }
-
+    
     init() {
-        // 必要ならここで接続開始
-        // connectWebSocket()
         // テスト用に初期状態をdetectingに設定
         self.appState = .detecting
+        setupBindings()
     }
     
-    private func handleStateChange(_ state: AppStatus) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            
-            switch state {
-            case .detecting:
-                break
-            case .success:
-                self.scheduleAutoReset()
-            case .waiting:
-                break
-            }
-        }
-    }
-    
-    private func scheduleAutoReset() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
-            self?.appState = .waiting
-        }
-    }
-    
-    private func connectWebSocket() {
-        guard let url = URL(string: "ws://localhost:8765") else { return }
-        webSocketTask = URLSession.shared.webSocketTask(with: url)
-        webSocketTask?.resume()
-        receiveMessage()
-    }
-    
-    private func receiveMessage() {
-        webSocketTask?.receive { [weak self] result in
-            guard let self = self else { return }
-            
-            switch result {
-            case .success(let message):
-                if case .string(let text) = message {
-                    DispatchQueue.main.async {
-                        let cleanText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        
-                        if let newState = AppStatus(rawValue: cleanText) {
-                            self.appState = newState
-                        } else {
-                            print("Warning: Unknown status received: '\(cleanText)'")
-                        }
-                    }
-                }
-                self.receiveMessage()
-                
-            case .failure(let error):
-                print("WebSocket Error: \(error)")
-                // 切断時は2秒後に再接続
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    self.connectWebSocket()
+    private func setupBindings() {
+        service.eventSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                guard let self = self else { return }
+                switch event {
+                case .heartDetected:
+                    self.appState = .success
+                default:
+                    break
                 }
             }
-        }
+            .store(in: &cancellables)
     }
 }

--- a/yt-mac-menu/yt-mac-menu/ViewModels/GestureDetectionViewModel.swift
+++ b/yt-mac-menu/yt-mac-menu/ViewModels/GestureDetectionViewModel.swift
@@ -16,8 +16,6 @@ class GestureDetectionViewModel: ObservableObject {
     }
     
     init() {
-        // テスト用に初期状態をdetectingに設定
-        self.appState = .detecting
         setupBindings()
     }
     
@@ -27,6 +25,8 @@ class GestureDetectionViewModel: ObservableObject {
             .sink { [weak self] event in
                 guard let self = self else { return }
                 switch event {
+                case .snapDetected:
+                    self.appState = .detecting
                 case .heartDetected:
                     self.appState = .success
                 default:

--- a/yt-mac-menu/yt-mac-menu/Views/GestureCameraView.swift
+++ b/yt-mac-menu/yt-mac-menu/Views/GestureCameraView.swift
@@ -3,7 +3,6 @@ import AVFoundation
 
 struct GestureCameraView: View {
     @StateObject private var gestureCameraViewModel = GestureCameraViewModel()
-    @Environment(\.dismiss) var dismiss
     
     var body: some View {
         ZStack {
@@ -29,11 +28,6 @@ struct GestureCameraView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.regularMaterial)
-        .onChange(of: gestureCameraViewModel.appState) { oldValue, newValue in
-            if newValue == .waiting {
-                dismiss()
-            }
-        }
     }
 }
 

--- a/yt-mac-menu/yt-mac-menu/Views/GestureCameraView.swift
+++ b/yt-mac-menu/yt-mac-menu/Views/GestureCameraView.swift
@@ -17,7 +17,12 @@ struct GestureCameraView: View {
                     color: .green
                 )
             case .waiting:
-                EmptyView()
+                StatusFeedbackSectionView(
+                    title: "読み込み中です",
+                    subtitle: "しばらくお待ちください...",
+                    iconName: "hourglass",
+                    color: .gray
+                )
             case .unauthorized:
                 VStack {
                     Image(systemName: "video.slash")

--- a/yt-mac-menu/yt-mac-menu/Views/GestureDetectionView.swift
+++ b/yt-mac-menu/yt-mac-menu/Views/GestureDetectionView.swift
@@ -16,7 +16,18 @@ struct GestureDetectionView: View {
                     color: .green
                 )
             case .waiting:
-                EmptyView()
+                StatusFeedbackSectionView(
+                    title: "読み込み中です",
+                    subtitle: "しばらくお待ちください...",
+                    iconName: "hourglass",
+                    color: .gray
+                )
+            case .unauthorized:
+                VStack {
+                    Image(systemName: "video.slash")
+                        .font(.largeTitle)
+                    Text("カメラの権限が必要です")
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Issue
- #24 
- #25 
- #26 

## 概要
- Issue-24：
- WindowのClose処理をappの方でするように修正。それに合わせてProgram側で閉じるcloseと手動で閉じるCloseを分岐するように修正(この変更は手動で落とした際にenable_snap状態に移行しない仕様等になる際に必要) 
- Python側へのCommandをAppViewModelで管理するよう修正
- Issue-25：
- waitingUIの実装
- GestureDetectionViewModelのWebSocketコマンド関連のメソッドを削除
- Issue-26：
- GestureCameraViewModelからWebSocketコマンドを送信しないよう削除 
- handCountは使わないため削除
- scheduleAutoResetをAppViewModelに移行し、3秒後にisCameraVisibleをfalseにするメソッドに変更しました