### PR TITLE
feat: カウントダウンを1.5秒・0.1秒粒度に変更してスムーズに表示

### DIFF
--- a/yt-mac-menu/yt-mac-menu/Presentation/Coordinators/AppCoordinator.swift
+++ b/yt-mac-menu/yt-mac-menu/Presentation/Coordinators/AppCoordinator.swift
@@ -5,7 +5,7 @@ import Combine
 
 struct GestureCountdown {
     let gestureType: GestureType
-    let secondsRemaining: Int
+    let secondsRemaining: Double
 }
 
 // MARK: - App Coordinator
@@ -277,20 +277,20 @@ class AppCoordinator: ObservableObject {
         cancelCountdown()
         
         currentGestureType = gestureType
-        var countdown = 3
+        var ticks = 15  // 1.5s × 10 ticks
         // 状態遷移なし - オーバーレイで表示
-        activeCountdown = GestureCountdown(gestureType: gestureType, secondsRemaining: countdown)
+        activeCountdown = GestureCountdown(gestureType: gestureType, secondsRemaining: Double(ticks) / 10.0)
         
-        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] timer in
+        countdownTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] timer in
             guard let self = self else {
                 timer.invalidate()
                 return
             }
             
-            countdown -= 1
+            ticks -= 1
             
-            if countdown > 0 {
-                self.activeCountdown = GestureCountdown(gestureType: gestureType, secondsRemaining: countdown)
+            if ticks > 0 {
+                self.activeCountdown = GestureCountdown(gestureType: gestureType, secondsRemaining: Double(ticks) / 10.0)
             } else {
                 timer.invalidate()
                 self.countdownTimer = nil

--- a/yt-mac-menu/yt-mac-menu/Presentation/Views/GestureCameraView.swift
+++ b/yt-mac-menu/yt-mac-menu/Presentation/Views/GestureCameraView.swift
@@ -38,7 +38,7 @@ struct GestureCameraView: View {
                         
                         // カウントダウンオーバーレイ
                         if let countdown = gestureCameraViewModel.currentCountdown {
-                            CountdownOverlayView(countdown: countdown, totalSeconds: 3)
+                            CountdownOverlayView(countdown: countdown, totalSeconds: 1.5)
                                 .transition(.scale.combined(with: .opacity))
                                 .animation(.easeInOut(duration: 0.3), value: countdown.secondsRemaining)
                         }
@@ -218,10 +218,10 @@ struct CameraPreviewView: NSViewRepresentable {
 
 struct CountdownOverlayView: View {
     let countdown: GestureCountdown
-    let totalSeconds: Int   // ← 追加
+    let totalSeconds: Double
     
     private var progress: Double {
-        Double(countdown.secondsRemaining) / Double(totalSeconds)
+        countdown.secondsRemaining / totalSeconds
     }
     
     var body: some View {
@@ -258,7 +258,7 @@ struct CountdownOverlayView: View {
                 .font(.title3.bold())
                 .foregroundColor(.white)
             
-            Text("\(countdown.secondsRemaining)秒後にアクションを実行します")
+            Text(String(format: "%.1f", countdown.secondsRemaining) + "秒後にアクションを実行します")
                 .font(.subheadline)
                 .foregroundColor(.white.opacity(0.8))
         }
@@ -361,5 +361,5 @@ struct PermissionDeniedView: View {
 }
 
 #Preview {
-    CountdownOverlayView(countdown: GestureCountdown(gestureType: .heart, secondsRemaining: 1), totalSeconds: 4)
+    CountdownOverlayView(countdown: GestureCountdown(gestureType: .heart, secondsRemaining: 0.75), totalSeconds: 1.5)
 }


### PR DESCRIPTION
- GestureCountdown.secondsRemaining を Int → Double に変更
- startCountdown() のタイマーを 1.0s → 0.1s 間隔に変更
- カウントダウン時間を 3秒 → 1.5秒 に短縮
- 内部カウントを ticks (Int) で管理し float 誤差を回避
- CountdownOverlayView.totalSeconds を Int → Double に変更
- 表示テキストを String(format: "%.1f", ...) でフォーマット